### PR TITLE
ヘッダーに "Accept: application/json" を入れることを明記

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ https://invoice.moneyforward.com/oauth/authorize?client_id=[CLIENT_ID]&redirect_
 curl -d client_id=[CLIENT_ID] -d client_secret=[CLIENT_SECRET] -d redirect_uri=[REDIRECT_URL] -d grant_type=authorization_code -d code=[認証コード] -X POST https://invoice.moneyforward.com/oauth/token
 ```
 
-※リクエストを送る際にパラメータは'Content-Type: application/x-www-form-urlencoded'である必要がある点に注意してください。
+※リクエストを送る際、下記2点について注意して下さい。
+
+* パラメータは `Content-Type: application/x-www-form-urlencoded` にする
+* `Accept: application/json` ヘッダーが必要
 
 ## アクセス数の制限について
 * Basicプラン以下のプランをご利用の場合、月のAPI経由での請求書作成数を100件までとさせていただきます。

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl -d client_id=[CLIENT_ID] -d client_secret=[CLIENT_SECRET] -d redirect_uri=[
 ※リクエストを送る際、下記2点について注意して下さい。
 
 * パラメータは `Content-Type: application/x-www-form-urlencoded` にする
-* `Accept: application/json` ヘッダーが必要
+* クライアントによっては `Accept: application/json` ヘッダーの明示が必要
 
 ## アクセス数の制限について
 * Basicプラン以下のプランをご利用の場合、月のAPI経由での請求書作成数を100件までとさせていただきます。


### PR DESCRIPTION
こんにちは。
MFCloud APIを使って業務の自動化を進めている会社のエンジニアです。
大変使いやすいAPIを公開して下さり誠にありがとうございます。

# 概要
このPRは、APIドキュメントにリクエストヘッダーとして "Accept: application/json" を入れることを明記するものです。

# 背景
例に挙げられている `curl` コマンドでは、デフォルトで `-H "Accept: */*"` になっています。（少なくとも `curl 7.55.1 x86_64-pc-linux-gnu` では）
なのでcurlでは問題なくリクエストできたのですが、例えばPHPのGuzzleHTTP/Guzzleからリクエストする時に、別途このヘッダーを設定する必要がありました。

私は `-H "Accept: application/json"` を設定することに気づかず数分ハマってしまったのですが、それはひとえに私の未熟さ故なので、このPRが受け入れられなくても問題はありません。
が、私のように未熟なエンジニアでもこのAPIをスムーズに使えるようになったら幸いです。

よろしくお願い致します。